### PR TITLE
Fix: type missmatch using LongPressHTMLElement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ const longPressStart = new CustomEvent('long-press-start')
 
 export const directiveOption = {
   bind (el: LongPressHTMLElement, binding: VNodeDirective, vnode: VNode) {
-    el.dataset.longPressTimeoutId = null
+    el.dataset.longPressTimeoutId = '0'
 
     const onmouseup = () => {
       clearTimeout(parseInt(el.dataset.longPressTimeoutId))


### PR DESCRIPTION
Set a different default value (`''`) for `longPressTimeoutId`, since null is not allowed and cannot be used with `parseInt`.